### PR TITLE
compatibility with base 4.11 and shell.nix file for good measure

### DIFF
--- a/4d-labyrinth.cabal
+++ b/4d-labyrinth.cabal
@@ -18,6 +18,6 @@ executable 4d-labyrinth
   main-is:             Main.hs
   -- other-modules:       
   other-extensions:    TemplateHaskell, Rank2Types, ScopedTypeVariables, DeriveFunctor
-  build-depends:       base >=4.9 && <4.11, OpenGL >=3.0 && <3.1, MonadRandom >=0.5 && <0.6, sdl2 >=2.2 && <2.4, lens >=4.15 && <4.16, linear >=1.20 && <1.21, containers >=0.5 && <0.6, bytestring >=0.10 && <0.11, filepath >=1.4 && <1.5, adjunctions >=4.3 && <4.4, array >=0.5 && <0.6, mtl >=2.2 && <2.3
+  build-depends:       base >=4.9 && <4.12, OpenGL >=3.0 && <3.1, MonadRandom >=0.5 && <0.6, sdl2 >=2.2 && <2.5, lens >=4.15 && <4.17, linear >=1.20 && <1.21, containers >=0.5 && <0.6, bytestring >=0.10 && <0.11, filepath >=1.4 && <1.5, adjunctions >=4.3 && <4.5, array >=0.5 && <0.6, mtl >=2.2 && <2.3
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,34 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, adjunctions, array, base, bytestring
+      , containers, filepath, lens, linear, MonadRandom, mtl, OpenGL
+      , sdl2, stdenv
+      }:
+      mkDerivation {
+        pname = "4d-labyrinth";
+        version = "0.1.0.0";
+        src = ./4d-labyrinth;
+        isLibrary = false;
+        isExecutable = true;
+        executableHaskellDepends = [
+          adjunctions array base bytestring containers filepath lens linear
+          MonadRandom mtl OpenGL sdl2
+        ];
+        license = stdenv.lib.licenses.gpl3;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv

--- a/src/Transformation.hs
+++ b/src/Transformation.hs
@@ -77,10 +77,13 @@ rotation plane angle = Transformation
 
 -- Composition and identity transformation.
 instance (SomeVector v, Num a) =>
+  Semigroup (Transformation v a) where
+  Transformation rot2 trans2 <> Transformation rot1 trans1 =
+    Transformation (rot2 !*! rot1) ((rot2 !* trans1) ^+^ trans2)
+
+instance (SomeVector v, Num a) =>
   Monoid (Transformation v a) where
   mempty = Transformation identity zero
-  mappend (Transformation rot2 trans2) (Transformation rot1 trans1) =
-    Transformation (rot2 !*! rot1) ((rot2 !* trans1) ^+^ trans2)
 
 -- Actually, rigid transformations form a group, not just a monoid.
 -- (And computing the inverse is not very expensive,


### PR DESCRIPTION
With these changes, 4d-labyrinth runs on current nixos-unstable.

I'm not sure whether the new `Semigroup` dependence of the `Monoid` class causes problems with the old `base` 4.10.